### PR TITLE
fix(auth): surface duplicate signup + handle bare-hash reset URLs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import { SocialProofStrip } from "@/components/marketing/SocialProofStrip";
 import { PricingTeaser } from "@/components/marketing/PricingTeaser";
 import { FinalCTA } from "@/components/marketing/FinalCTA";
 import { JsonLd } from "@/components/seo/JsonLd";
+import { RootAuthHashCatcher } from "@/components/RootAuthHashCatcher";
 
 const description =
   "Practice typing. Get measurably faster. Free desktop typing tutor for Mac, Windows, and Linux. Real-time PvP, AI coach, and deep stats.";
@@ -42,6 +43,7 @@ export const viewport: Viewport = {
 export default function Page() {
   return (
     <main>
+      <RootAuthHashCatcher />
       <JsonLd
         id="ld-software-app"
         data={{

--- a/src/components/RootAuthHashCatcher.tsx
+++ b/src/components/RootAuthHashCatcher.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Defensive root-level handler for Supabase auth links that land at `/`
+// instead of `/auth/callback`. This happens when:
+//   1. The `redirect_to` we send to Supabase isn't on the project's allow-list,
+//      so Supabase falls back to Site URL (= the root) with tokens in the hash.
+//   2. Older password-reset / signup-confirmation emails were sent before
+//      the allow-list was correct.
+//   3. OAuth providers that always return to Site URL by spec.
+//
+// When we detect `#access_token=...` or `#error=...` in the hash on `/`,
+// we forward to `/auth/callback` preserving the entire hash so the existing
+// AuthCallbackHandler can call setSession + route to /auth/set-password.
+//
+// Renders nothing.
+export function RootAuthHashCatcher() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash;
+    if (!hash || hash.length < 2) return;
+    // Match any of the param names Supabase emits on recovery / magic-link
+    // / OAuth-implicit flows. Errors get forwarded too so the callback
+    // handler renders the explanatory message rather than silently dropping.
+    if (
+      !/\b(access_token|refresh_token|provider_token|error|error_description|type=recovery|type=signup|type=magiclink|type=invite)\b/.test(
+        hash,
+      )
+    ) {
+      return;
+    }
+    // Use replace so the user's back-button doesn't bounce them back to
+    // /#access_token and re-trigger the redirect.
+    window.location.replace(`/auth/callback${hash}`);
+  }, []);
+
+  return null;
+}

--- a/src/components/SignUp/index.tsx
+++ b/src/components/SignUp/index.tsx
@@ -70,6 +70,25 @@ export default function SignUp() {
                   return;
                 }
 
+                // Supabase anti-enumeration: when an email is already
+                // registered, /signup returns 200 with a synthetic user
+                // whose `identities` is an empty array — and no confirmation
+                // email is sent. Surface this so users (especially Cognito-
+                // migrated ones with a placeholder password) get routed to
+                // sign-in / password reset instead of waiting for an email.
+                if (data.user && (data.user.identities?.length ?? 0) === 0) {
+                  toast(Notification, {
+                    type: "error",
+                    data: {
+                      title: "Account already exists",
+                      message:
+                        "If you already have an account, please sign in instead — or reset your password if you don't remember it.",
+                      type: "error",
+                    },
+                  });
+                  return;
+                }
+
                 // Check if email confirmation is required
                 if (data.user && !data.session) {
                   // Email confirmation required


### PR DESCRIPTION
## Two related auth fixes

### 1. Duplicate-signup detection (`f41f81b`)
Supabase Auth (GoTrue) anti-enumeration returns 200 with `data.user.identities = []` on duplicate-email signup and sends **no** email. The handler treated that as success and showed "Check Your Email" → user waited forever. Especially painful for Cognito-migrated users (created during the 2026-01-17 migration with `email_confirmed_at` pre-set and a placeholder bcrypt hash they don't know). They can't sign in either, and the silent signup hides that they need to use Forgot Password.

Now detects `data.user.identities?.length === 0` and shows an "Account already exists" toast routing them to sign-in / password reset.

### 2. Bare-hash auth-link catcher at `/` (`db4b4ce`)
Supabase falls back to **Site URL** (= `/`) with tokens in the hash when the `redirect_to` passed to `resetPasswordForEmail` isn't on the project's allow-list. That landed users on `https://touch-typer.kochie.io/#access_token=…` where the marketing page has no logic to consume the token.

Proper fix is to add `https://touch-typer.kochie.io/auth/callback` to the Redirect URLs allow-list in Supabase Dashboard → Authentication → URL Configuration. **That's a config change, not in this PR.**

Defense-in-depth code: `RootAuthHashCatcher` (a no-render client component on `/`) detects auth-shaped hash params and forwards to `/auth/callback` preserving the fragment. The existing `AuthCallbackHandler` then calls `setSession` and routes to `/auth/set-password`. Handles:
- Old emails already out there that point to the bad redirect
- Future misconfigurations
- OAuth providers that always return to Site URL by spec

## Trade-off on #1
This *slightly* increases enumeration leakage at the signup endpoint. Acceptable because (a) login is already enumeration-resistant ("Invalid login credentials" for both wrong-password and no-account), (b) Forgot Password is enumeration-resistant (200 regardless), and (c) the value of confirming Touch Typer membership to an attacker is essentially nil for a typing app.

## Test plan
- [ ] Add `https://touch-typer.kochie.io/auth/callback` to Supabase Dashboard → Auth → URL Configuration → Redirect URLs **before merging this**
- [ ] Sign up with an email that already exists → "Account already exists" toast, no "Check Your Email" wait
- [ ] Sign up with a fresh email → normal flow + Resend logs a "Confirm Your Signup"
- [ ] Run Forgot Password on a real account → click email link → land on `/auth/set-password` (whether through `/auth/callback` directly or via root-catcher fallback)
- [ ] Open `https://touch-typer.kochie.io/#access_token=foo&type=recovery` manually → confirm root-catcher forwards to `/auth/callback#…`
- [ ] Confirm regular visits to `/` (no hash) render the marketing page normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)